### PR TITLE
feat: add staging pipeline and BackendConfig

### DIFF
--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -82,3 +82,55 @@ jobs:
         run: |
           cd ${{ matrix.path }}
           make image/build-and-push
+
+  deploy-to-staging:
+    needs: [ build-makefile ]
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        application:
+          - developer-portal
+    env:
+      APP_NAME: ${{ matrix.application }}
+      Z_ENV: infra/live/gcp/non-production/prj-d-staging/z_ase1.yaml
+      Z_SERVICE_ACCOUNT: ${{ secrets.GCP_STG_GITHUB_SA_K8S_DEPLOY }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_STG }}
+      GITHUB_PAT: ${{ secrets.GH_PAT }}
+      Z_IMAGE: asia-docker.pkg.dev/prj-d-devops-services-4dgwlsse/zilliqa-private/z:latest
+      REGISTRY: asia-docker.pkg.dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: Zilliqa/devops
+          token: ${{ env.GITHUB_PAT }}
+          ref: main
+          sparse-checkout: |
+            ${{ env.Z_ENV }}
+      
+      - name: Authenticate to Google Cloud
+        id: google-auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+          service_account: ${{ env.Z_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+
+      - name: Deploy application
+        run: |
+          gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://${{ env.REGISTRY }}
+          docker run --rm \
+              -e ZQ_USER='${{ env.Z_SERVICE_ACCOUNT }}' \
+              -e Z_ENV='/devops/${{ env.Z_ENV }}' \
+              -e OP_SERVICE_ACCOUNT_TOKEN='${{ env.OP_SERVICE_ACCOUNT_TOKEN }}' \
+              -e GITHUB_PAT='${{ env.GITHUB_PAT }}' \
+              -e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE='/google/application_default_credentials.json' \
+              -v `pwd`:/devops \
+              -v ${{ steps.google-auth.outputs.credentials_file_path }}:/google/application_default_credentials.json \
+              --name z_container ${{ env.Z_IMAGE }} \
+              bash -c "gcloud config set account ${{ env.Z_SERVICE_ACCOUNT }} && z /app /devops app sync --cache-dir .cache ${{ env.APP_NAME }}"

--- a/cd/base/backend-config.yaml
+++ b/cd/base/backend-config.yaml
@@ -1,0 +1,11 @@
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: developer-portal
+  namespace: developer-portal
+  labels:
+    app.kubernetes.io/name: "developer-portal"
+spec:
+  timeoutSec: 120
+  healthCheck:
+    requestPath: /zilliqa2/

--- a/cd/base/frontend-config.yaml
+++ b/cd/base/frontend-config.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig
 metadata:
   name: developer-portal
+  namespace: developer-portal
+  labels:
+    app.kubernetes.io/name: "developer-portal"
 spec:
   redirectToHttps:
     enabled: true

--- a/cd/base/kustomization.yaml
+++ b/cd/base/kustomization.yaml
@@ -5,3 +5,5 @@ resources:
   - deployment.yaml
   - svc.yaml
   - ingress.yaml
+  - backend-config.yaml
+  - frontend-config.yaml

--- a/cd/base/svc.yaml
+++ b/cd/base/svc.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: developer-portal
   labels:
     app.kubernetes.io/name: "developer-portal"
+  annotations:
+    beta.cloud.google.com/backend-config: '{"default": "developer-portal"}'
 spec:
   type: ClusterIP
   ports:

--- a/cd/overlays/production/kustomization.yaml
+++ b/cd/overlays/production/kustomization.yaml
@@ -4,7 +4,6 @@ kind: Kustomization
 resources:
   - ../../base
   - certificate.yaml
-  - frontend-config.yaml
 
 patches:
   - target:


### PR DESCRIPTION
In `starting-your-node.md`, include explicit instructions for upgrading node binaries and configs with an emphasis on setting `do_checkpoints=true`. Provide an example snippet:

```bash
# Upgrade the node binary
docker pull <latest_zq2_image>

docker stop <container_id>

# Update config files to support checkpoints
# In your config file:
do_checkpoints = true

# Optionally, specify checkpoint file
load_checkpoint = { file = "checkpoint.zip", hash = "abc123..." }

# Restart node
./start_node.sh
```

Remind users to perform this upgrade before the scheduled hard fork block height.