### PR TITLE
feat: add production pipeline

### DIFF
--- a/.github/workflows/cicd-prd.yml
+++ b/.github/workflows/cicd-prd.yml
@@ -92,3 +92,56 @@ jobs:
         run: |
           cd ${{ matrix.path }}
           make image/build-and-push
+
+  deploy-to-production:
+    needs: [build-makefile]
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release'
+    strategy:
+      fail-fast: false
+      matrix:
+        application:
+          - developer-portal
+    env:
+      APP_NAME: ${{ matrix.application }}
+      Z_ENV: infra/live/gcp/production/prj-p-prod-apps/z_ase1.yaml
+      Z_SERVICE_ACCOUNT: ${{ secrets.GCP_PRD_GITHUB_SA_K8S_DEPLOY }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN_PRD }}
+      GITHUB_PAT: ${{ secrets.GH_PAT }}
+      Z_IMAGE: asia-docker.pkg.dev/prj-p-devops-services-tvwmrf63/zilliqa-private/z:latest
+      REGISTRY: asia-docker.pkg.dev
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          repository: Zilliqa/devops
+          token: ${{ env.GITHUB_PAT }}
+          ref: main
+          sparse-checkout: |
+            ${{ env.Z_ENV }}
+
+      - name: Authenticate to Google Cloud
+        id: google-auth
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: "access_token"
+          workload_identity_provider: "${{ secrets.GCP_PRD_GITHUB_WIF }}"
+          service_account: ${{ env.Z_SERVICE_ACCOUNT }}
+          create_credentials_file: true
+
+      - name: Deploy application
+        run: |
+          gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin https://${{ env.REGISTRY }}
+          docker run --rm \
+              -e ZQ_USER='${{ env.Z_SERVICE_ACCOUNT }}' \
+              -e Z_ENV='/devops/${{ env.Z_ENV }}' \
+              -e OP_SERVICE_ACCOUNT_TOKEN='${{ env.OP_SERVICE_ACCOUNT_TOKEN }}' \
+              -e GITHUB_PAT='${{ env.GITHUB_PAT }}' \
+              -e CLOUDSDK_AUTH_CREDENTIAL_FILE_OVERRIDE='/google/application_default_credentials.json' \
+              -v `pwd`:/devops \
+              -v ${{ steps.google-auth.outputs.credentials_file_path }}:/google/application_default_credentials.json \
+              --name z_container ${{ env.Z_IMAGE }} \
+              bash -c "gcloud config set account ${{ env.Z_SERVICE_ACCOUNT }} && z /app /devops app sync --cache-dir .cache ${{ env.APP_NAME }}"

--- a/.github/workflows/cicd-stg.yml
+++ b/.github/workflows/cicd-stg.yml
@@ -84,11 +84,12 @@ jobs:
           make image/build-and-push
 
   deploy-to-staging:
-    needs: [ build-makefile ]
+    needs: [build-makefile]
     permissions:
       id-token: write
       contents: write
     runs-on: ubuntu-22.04
+    if: github.actor != 'dependabot[bot]' && github.ref_name == 'main'
     strategy:
       fail-fast: false
       matrix:
@@ -111,7 +112,7 @@ jobs:
           ref: main
           sparse-checkout: |
             ${{ env.Z_ENV }}
-      
+
       - name: Authenticate to Google Cloud
         id: google-auth
         uses: google-github-actions/auth@v2


### PR DESCRIPTION
Update `chain-specification.md` with a sample configuration snippet for the protocol upgrade parameters and checkpoint support:

```toml
# In your chain spec file
[protocol.upgrade]
scheduled_block_height = 11998800  # Mainnet hard fork

[nodes.load_checkpoint]
file = "checkpoint.zip"
hash = "abc123..."

# Remember to set do_checkpoints=true in your node config
```

This helps guide node operators in preparing their chain spec files for the upgrade, ensuring they include the scheduled fork height and checkpoint parameters, with `do_checkpoints=true` enabled.