### PR TITLE
(fix) Use PyYAML 6.0.1 so that requirements will install on Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ Pygments==2.15.0
 pymdown-extensions==10.0
 pyparsing==3.0.9
 python-dateutil==2.8.2
-PyYAML==6.0
+PyYAML==6.0.1
 pyyaml_env_tag==0.1
 requests==2.31.0
 six==1.16.0


### PR DESCRIPTION
Fixes #15 