### PR TITLE
Fix faucet link and iframe

### DIFF
--- a/zq2/docs/endpoints.md
+++ b/zq2/docs/endpoints.md
@@ -37,7 +37,7 @@ The faucet sends an amount of 100 ZIL to the supplied address for use in testing
 Enter the hex address of your compatible EVM wallet into the field below to receive 100 ZIL on the Zilliqa 2.0 proto-testnet:
 
 <div class="fish">
- <iframe width="80%" height="200px" src="https://faucet.zq2-devnet.zilliqa.com/">
+ <iframe width="80%" height="200px" src="https://faucet.zq2-prototestnet.zilliqa.com/">
  </div>
 
-_If you are unable to use the tool above, you can also [access the faucet here](https://faucet.devnet.zilliqa.com)._
+_If you are unable to use the tool above, you can also [access the faucet here](https://faucet.zq2-prototestnet.zilliqa.com)._


### PR DESCRIPTION
The text says the faucet belongs to the proto-testnet but the links refer to the devnet.