### PR TITLE
Make dev-portal build again now that the zq2 commit it points to no longer exists (because merged)

### DIFF
--- a/docgen/src/main.rs
+++ b/docgen/src/main.rs
@@ -269,7 +269,17 @@ async fn main() -> Result<()> {
             if fs::metadata(zq2_checkout_dir.clone().join(".git")).is_ok() {
                 // Update.
                 CommandBuilder::new()
-                    .cmd("git", &["pull", "https://github.com/zilliqa/zq2", refspec])
+                    .cmd(
+                        "git",
+                        &[
+                            "fetch",
+                            "--depth=1",
+                            "-f",
+                            "-u",
+                            "https://github.com/zilliqa/zq2",
+                            refspec,
+                        ],
+                    )
                     .current_dir(&zq2_checkout_dir.clone())?
                     .run_logged()
                     .await?

--- a/zq2_spec.yaml
+++ b/zq2_spec.yaml
@@ -1,4 +1,4 @@
 versions:
-  - refspec: 4914811983d965da3eb176979984ca219aa8bbc3
+  - refspec: 033cc034a083151fded32092437302d042fe80ee
     name: APIs
     api_url: "https://api.zq2-prototestnet.zilliqa.com/"


### PR DESCRIPTION
(fix) Move zq2 back onto mainline
(fix) Try yet again to get git to update the cached zq2 sensibly