### PR TITLE
Update ZQ2 Testnet `deposit_v7` Contract Activation Block Height

### DIFF
--- a/zq2/docs/nodes/node.md
+++ b/zq2/docs/nodes/node.md
@@ -18,8 +18,7 @@ Users can set up a node and join the Zilliqa 2.0 mainnet, testnet or devnet by f
 - **Disk**:
     - 200 GB or more
 
-We are running our Zilliqa 2.0 Nodes on Google Cloud Platform, GCP,
-GCE VM `e2-highcpu-8` instance with 256 GB SSD (`pd-ssd`).
+We are running our Zilliqa 2.0 Nodes on Google Cloud Platform, GCP, GCE VM `e2-highcpu-8` instance with 256 GB SSD (`pd-ssd`).
 
 ### [Software requirements](#software-requirements)
 
@@ -28,11 +27,9 @@ GCE VM `e2-highcpu-8` instance with 256 GB SSD (`pd-ssd`).
 
 ### [Port-forwarding](#port-forwarding)
 
-The following TCP ports need to be open to the internet for both inbound and
-outbound.
+The following TCP ports need to be open to the internet for both inbound and outbound.
 
-_NOTE: We don't recommend to run Nodes behind a NAT, if you're doing so
-and you are facing any traversal issue you might have to debug on your own._
+_NOTE: We don't recommend to run Nodes behind a NAT, if you're doing so and you are facing any traversal issue you might have to debug on your own._
 
 #### Required
 
@@ -52,47 +49,47 @@ To configure a node and join a Zilliqa 2.0 network, we provide the `z2` utility 
 base. Follow the step by step guide to setup your node:
 
 1. Cargo and Rust: You need to have Cargo and Rust installed on your system.
-  You can install them using [rustup](https://rustup.rs/). Once rustup is installed,
-  you can update Rust to the latest stable version.
+   You can install them using [rustup](https://rustup.rs/). Once rustup is installed,
+   you can update Rust to the latest stable version.
 2. Install the following requirements:
-  ```bash
-  sudo add-apt-repository ppa:ethereum/ethereum && sudo apt update && \
-  sudo apt install -y solc build-essential pkg-config libssl-dev cmake \
-  protobuf-compiler
-  ```
+   ```bash
+   sudo add-apt-repository ppa:ethereum/ethereum && sudo apt update && \
+   sudo apt install -y solc build-essential pkg-config libssl-dev cmake \
+   protobuf-compiler
+   ```
 3. Pick a directory. You'll need quite a lot of space. Let's call it `/my/dir`.
 4. Clone [zq2](https://github.com/zilliqa/zq2) sourcecode into that directory to get `/my/dir/zq2`.
 
 5. Build the code using `cargo build`.
 6. Source the setenv file:
-  ```bash
-  source /my/dir/zq2/scripts/setenv
-  ```
-  This will give you access to the `z2` tool (in `zq2/z2`).
+   ```bash
+   source /my/dir/zq2/scripts/setenv
+   ```
+   This will give you access to the `z2` tool (in `zq2/z2`).
 7. Generate the startup script and the configuration file for your node by running:
-  ```bash
-  z2 join --chain zq2-mainnet
-  ```
-  _NOTE: You can replace zq2-mainnet with `zq2-testnet` or `zq2-devnet` depending on
-  which network you want your node to join._
+   ```bash
+   z2 join --chain zq2-mainnet
+   ```
+   _NOTE: You can replace `zq2-mainnet` with `zq2-testnet` or `zq2-devnet` depending on
+   which network you want your node to join._
 
-8. (Optional) A Zilliqa node contains various performance and operational metrics compatible with the OpenTelemetry 
-  protocol specification. If you want to export these metrics you can define a [collector](https://opentelemetry.io/docs/collector/) 
-  endpoint with the `--otlp-endpoint` parameter in `z2 join` pointing to your own OpenTelemetry monitoring stack, for example:
-  ```bash
-  z2 join --chain  zq2-mainnet --otlp-endpoint=http://localhost:4317
-  ```
-  _NOTE: For more details on testing and using the available OpenTelemetry 
-  metrics refer to the [OpenTelemetry](monitoring/opentelemetry.md) page._
+8. (Optional) A Zilliqa node contains various performance and operational metrics compatible with the OpenTelemetry
+   protocol specification. If you want to export these metrics you can define a [collector](https://opentelemetry.io/docs/collector/)
+   endpoint with the `--otlp-endpoint` parameter in `z2 join` pointing to your own OpenTelemetry monitoring stack, for example:
+   ```bash
+   z2 join --chain  zq2-mainnet --otlp-endpoint=http://localhost:4317
+   ```
+   _NOTE: For more details on testing and using the available OpenTelemetry
+   metrics refer to the [OpenTelemetry](monitoring/opentelemetry.md) page._
 
 9. Generate the node private key.
-  ```bash
-  openssl rand -hex 32 > node-private-key.txt
-  export PRIVATE_KEY=$(cat node-private-key.txt)
-  ```
-  _NOTE: Please save the node key as described above. You may need it
-  in the future to restart the node to generate the BLS public
-  key of the node._
+   ```bash
+   openssl rand -hex 32 > node-private-key.txt
+   export PRIVATE_KEY=$(cat node-private-key.txt)
+   ```
+   _NOTE: Please save the node key as described above. You may need it
+   in the future to restart the node to generate the BLS public
+   key of the node._
 
 10. Now it's time to synchronize the node with the network. For networks created using Zilliqa 2, the node can be synchronized from the genesis. However, for networks such as mainnet and testnet that migrated from Zilliqa 1, the node must be synchronized from a checkpoint:
 
@@ -109,13 +106,13 @@ Please refer to [Syncing & Pruning](../nodes/passive-pruning.md) for information
 ### [Starting your node](#starting-your-node)
 Since only devnet nodes can sync from the genesis, all other nodes must be started from a checkpoint: 
 
-* <b>start the node from a checkpoint:</br></b>
+* <b>start the node from a checkpoint:</b>
   ```bash
   chmod +x start_node.sh && \
   ./start_node.sh -k $PRIVATE_KEY -p <checkpoint_block_num.dat>
   ```
 
-* <b>start the node from the genesis:</br></b>
+* <b>start the node from the genesis:</b>
   ```bash
   chmod +x start_node.sh && \
   ./start_node.sh -k $PRIVATE_KEY
@@ -196,3 +193,9 @@ You can validate the version your node is running by calling the `GetVersion` AP
 ```bash
 curl --request POST --url http://localhost:4202 --header 'content-type: application/json' --data '{"method":"GetVersion","id":1,"jsonrpc":"2.0"}'
 ```
+
+:::note
+**Upcoming `deposit_v7` Contract Upgrade on ZQ2 Testnet**
+
+The `deposit_v7` contract upgrade on the ZQ2 testnet is scheduled to activate at block height `17,010,000`. This activation height has been postponed from the previously announced `16,934,100`. Please ensure your node is updated accordingly before the new activation block.
+:::


### PR DESCRIPTION
The activation block height for the `deposit_v7` contract upgrade on the ZQ2 testnet has been updated. The upgrade is now scheduled to occur at block height `17,010,000`, postponed from the previously specified height of `16,934,100`. This change affects the timing of new deposit contract features becoming available on the testnet. Node operators on the ZQ2 testnet should ensure their configuration reflects this new block height to remain in sync with the network.